### PR TITLE
Reduce character count of the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: Create a report to help us improve FreeRTOS STM32U5 IoT Reference. This should
-  only be used for confirmed bugs. If you suspect something it is best to first discuss
-  it on the FreeRTOS forums linked below.
+about: Create a report to help us improve FreeRTOS STM32U5 IoT Reference. Please use this
+       for confirmed bugs only. If you suspect something it is best to first discuss it on
+       the FreeRTOS forums linked below.
 title: "[BUG]"
 labels: bug
 assignees: ''


### PR DESCRIPTION
The 'about' section should not be larger than 200 bytes. This PR rewords that section so that requirement is met.