### PR TITLE
fix: mbedtls_transport now prints a valid IP

### DIFF
--- a/Common/include/mbedtls_error_utils.h
+++ b/Common/include/mbedtls_error_utils.h
@@ -47,22 +47,22 @@
     mbedtls_low_level_strerr( mbedTlsCode ) : ( const char * ) "<No-Low-Level-Code>"
 #endif /* mbedtlsLowLevelCodeOrDefault */
 
-#define MBEDTLS_MSG_IF_ERROR( lError, pMessage )            \
-    do                                                      \
-    {                                                       \
-        if( lError < 0 )                                    \
-        LogError( pMessage " %s : %s.",                     \
-                  mbedtlsHighLevelCodeOrDefault( lError ),  \
-                  mbedtlsLowLevelCodeOrDefault( lError ) ); \
+#define MBEDTLS_MSG_IF_ERROR( lError, pMessage )                  \
+    do                                                            \
+    {                                                             \
+        if( lError < 0 ) {                                        \
+            LogError( pMessage " %s : %s.",                       \
+                      mbedtlsHighLevelCodeOrDefault( lError ),    \
+                      mbedtlsLowLevelCodeOrDefault( lError ) ); } \
     } while( 0 )
 
-#define MBEDTLS_LOG_IF_ERROR( lError, pFormatString, ... )  \
-    do                                                      \
-    {                                                       \
-        if( lError < 0 )                                    \
-        LogError( pFormatString " %s : %s.", __VA_ARGS__,   \
-                  mbedtlsHighLevelCodeOrDefault( lError ),  \
-                  mbedtlsLowLevelCodeOrDefault( lError ) ); \
+#define MBEDTLS_LOG_IF_ERROR( lError, pFormatString, ... )        \
+    do                                                            \
+    {                                                             \
+        if( lError < 0 ) {                                        \
+            LogError( pFormatString " %s : %s.", __VA_ARGS__,     \
+                      mbedtlsHighLevelCodeOrDefault( lError ),    \
+                      mbedtlsLowLevelCodeOrDefault( lError ) ); } \
     } while( 0 )
 
 #endif /* _MBEDTLS_UTILS_H */

--- a/Common/net/mbedtls_transport.c
+++ b/Common/net/mbedtls_transport.c
@@ -1136,8 +1136,7 @@ static TlsTransportStatus_t xConnectSocket( TLSContext_t * pxTLSCtx,
             if( pxAddrIter->ai_family == AF_INET )
             {
                 char ipAddrBuff[ IP4ADDR_STRLEN_MAX ] = { 0 };
-                ( void ) inet_ntoa_r( pxAddrIter->ai_addr, ipAddrBuff, IP4ADDR_STRLEN_MAX );
-
+                ( void ) inet_ntoa_r( ( ( struct sockaddr_in * ) pxAddrIter->ai_addr )->sin_addr, ipAddrBuff, IP4ADDR_STRLEN_MAX );
                 LogInfo( "Trying address: %.*s, port: %uh for host: %s.",
                          IP4ADDR_STRLEN_MAX, ipAddrBuff, usPort, pcHostName );
             }
@@ -1146,6 +1145,7 @@ static TlsTransportStatus_t xConnectSocket( TLSContext_t * pxTLSCtx,
             if( pxAddrIter->ai_family == AF_INET6 )
             {
                 char ipAddrBuff[ IP6ADDR_STRLEN_MAX ] = { 0 };
+                ( void ) inet6_ntoa_r( ( ( struct sockaddr_in6 * ) pxAddrIter->ai_addr )->sin_addr, ipAddrBuff, IP6ADDR_STRLEN_MAX );
                 LogInfo( "Trying address: %.*s, port: %uh for host: %s.",
                          IP6ADDR_STRLEN_MAX, ipAddrBuff, usPort, pcHostName );
             }
@@ -1179,17 +1179,19 @@ static TlsTransportStatus_t xConnectSocket( TLSContext_t * pxTLSCtx,
                     if( pxAddrIter->ai_family == AF_INET )
                     {
                         char ipAddrBuff[ IP4ADDR_STRLEN_MAX ] = { 0 };
-                        ( void ) inet_ntoa_r( pxAddrIter->ai_addr, ipAddrBuff, IP4ADDR_STRLEN_MAX );
+
+                        ( void ) inet_ntoa_r( ( ( struct sockaddr_in * ) pxAddrIter->ai_addr )->sin_addr, ipAddrBuff, IP4ADDR_STRLEN_MAX );
 
                         LogInfo( "Connected socket: %ld to host: %s, address: %.*s, port: %uh.",
                                  pxTLSCtx->xSockHandle, pcHostName,
                                  IP4ADDR_STRLEN_MAX, ipAddrBuff, usPort );
                     }
-#endif
+#endif /* if LWIP_IPV4 == 1 */
 #if LWIP_IPV6 == 1
                     if( pxAddrIter->ai_family == AF_INET6 )
                     {
                         char ipAddrBuff[ IP6ADDR_STRLEN_MAX ] = { 0 };
+                        ( void ) inet6_ntoa_r( ( ( struct sockaddr_in6 * ) pxAddrIter->ai_addr )->sin_addr, ipAddrBuff, IP6ADDR_STRLEN_MAX );
                         LogInfo( "Connected socket: %ld to host: %s, address: %.*s, port: %uh.",
                                  pxTLSCtx->xSockHandle, pcHostName,
                                  IP6ADDR_STRLEN_MAX, ipAddrBuff, usPort );


### PR DESCRIPTION
A bogus IP was printed to the console while I was troubleshooting connectivity.

`inet_ntoa_r` requires a valid IP address in order to format a string.
A pointer was instead given to the `sockaddr_in` struct, 
which contains the family and port at the beginning, not the address.

The IPv6 portion of this fix is untested.