### PR TITLE
fix: cli_conf checks argument count to `conf set`

### DIFF
--- a/Common/cli/cli_conf.c
+++ b/Common/cli/cli_conf.c
@@ -223,13 +223,13 @@ static void vSubCommand_SetConfig( ConsoleIO_t * pxCIO,
                                    uint32_t ulArgc,
                                    char * ppcArgv[] )
 {
-    const char * pcKey = ppcArgv[ 2 ];
+    const char * pcKey = ppcArgv[ KEY_ARG_IDX ];
 
     const char * pcValue = "";
 
     if( ulArgc > VALUE_ARG_IDX )
     {
-        pcValue = ppcArgv[ 3 ];
+        pcValue = ppcArgv[ VALUE_ARG_IDX ];
     }
 
     BaseType_t xParseResult = pdFALSE;
@@ -397,8 +397,16 @@ static void vCommand_Configure( ConsoleIO_t * pxCIO,
         }
         else if( 0 == strcmp( "set", pcMode ) )
         {
-            vSubCommand_SetConfig( pxCIO, ulArgc, ppcArgv );
-            xSuccess = pdTRUE;
+            /* set cannot be used without arguments */
+            if( ulArgc > KEY_ARG_IDX )
+            {
+                vSubCommand_SetConfig( pxCIO, ulArgc, ppcArgv );
+                xSuccess = pdTRUE;
+            }
+            else
+            {
+                xSuccess = pdFALSE;
+            }
         }
         else if( 0 == strcmp( "commit", pcMode ) )
         {


### PR DESCRIPTION
On a board running the ntz demo, entering `conf set` with no other arguments results in trying to read a key argument when there is none, resulting in a buffer overrun.