### PR TITLE
FreeRTOS awareness in CubeIDE gdb server config

### DIFF
--- a/Common/cli/cli_utils.c
+++ b/Common/cli/cli_utils.c
@@ -181,7 +181,7 @@ static inline const char * pceTaskStateToString( eTaskState xState )
 
 static uint32_t ulGetStackDepth( TaskHandle_t xTask )
 {
-    struct tskTaskControlBlock
+    struct tskTaskControlBlockRedef
     {
         volatile StackType_t * pxDontCare0;
 
@@ -198,7 +198,7 @@ static uint32_t ulGetStackDepth( TaskHandle_t xTask )
         StackType_t * pxEndOfStack;
 #endif
     };
-    struct tskTaskControlBlock * pxTCB = ( struct tskTaskControlBlock * ) xTask;
+    struct tskTaskControlBlockRedef * pxTCB = ( struct tskTaskControlBlockRedef * ) xTask;
 
     return( ( ( ( uintptr_t ) pxTCB->pxEndOfStack - ( uintptr_t ) pxTCB->pxStack ) / sizeof( StackType_t ) ) + 2 );
 }


### PR DESCRIPTION
Workaround for the STM32CubeIDE gdb FreeRTOS kernel awareness tool:

Redefining the tskTaskControlBlock struct, even locally, confuses the tool, which is not able to recover the callstrack context of each RTOS tasks.

Using a different name avoids the confusion, and restores the STM32CubeIDE debug view.