### PR TITLE
Initialize the dynamically-allocated transport context

### DIFF
--- a/Common/net/mbedtls_transport.c
+++ b/Common/net/mbedtls_transport.c
@@ -471,6 +471,7 @@ NetworkContext_t * mbedtls_transport_allocate( void )
     }
     else
     {
+        memset( pxTLSCtx, 0, sizeof( TLSContext_t ) );
         pxTLSCtx->xConnectionState = STATE_ALLOCATED;
         pxTLSCtx->xSockHandle = -1;
         mbedtls_ssl_config_init( &( pxTLSCtx->xSslConfig ) );


### PR DESCRIPTION
Initialize the dynamically-allocated transport context.

If not done, the pxNotifyThreadCtx field happens to be invalid (depending on past heap usage).
For instance it can result in a hardfault (jumping to address 0xffffffff) in the MQTT_Connect_LWT test case if the MQTT test group is run after the transport test group.