### PR TITLE
PSA public key update

### DIFF
--- a/Common/crypto/PkiObjectPsa.c
+++ b/Common/crypto/PkiObjectPsa.c
@@ -441,6 +441,17 @@ int32_t lWritePublicKeyToPSACrypto( psa_key_id_t xPubKeyId,
         xStatus = PSA_ERROR_NOT_SUPPORTED;
     }
 
+    if( xStatus == PSA_SUCCESS )
+    {
+        xStatus = psa_destroy_key( xPubKeyId );
+    }
+
+    /* Mask invalid handle error since key may not exist */
+    if( xStatus == PSA_ERROR_INVALID_HANDLE )
+    {
+        xStatus = PSA_SUCCESS;
+    }
+
     /* Export key to PSA */
     if( xStatus == PSA_SUCCESS )
     {


### PR DESCRIPTION
Allow to update the code signing public key through the PSA PKI object implementation.

Description
-----------
In PSA/TrustZone configuration, once the code signing public key has been set by the user through the CLI, it cannot be overwitten.

The current method in the FreeRTOS reference integration for STM32u5 is to perform a regression of the trusted storage used by the PSA crypto implementation, and do the device provisioning from scratch again.

This pull request provides an alternative: Delete the key first, then write new contents.
It follows the same pattern as the CLI keypair generation, in lGenerateKeyPairECPsaCrypto().

Test Steps
-----------
Run "> pki import key ota_signer_pub" from the CLI a couple of times, and ensure the latter is successful.
