### PR TITLE
CI: Update to STM32CubeIDE 1.12.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,9 @@ on:
       - dev
       - main
   workflow_dispatch:
+  # Run every Monday and Thursday at 04:30
+  schedule:
+    - cron: '30 4 * * 1,4'
 
 jobs:
   ubuntu:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,10 @@ jobs:
         project: [b_u585i_iot02a_ntz, b_u585i_iot02a_tfm]
         include:
           - os: ubuntu-latest
-            ide_pkg_name: "st-stm32cubeide_1.11.0_13638_20221122_1308_amd64"
-            ide_pkg_url: "https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/0c/78/32/f9/97/af/49/e3/stm32cubeide_lnx/files/st-stm32cubeide_1.11.0_13638_20221122_1308_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.11.0_13638_20221122_1308_amd64.sh.zip"
+            ide_pkg_name: "st-stm32cubeide_1.12.1_16088_20230420_1057_amd64"
+            ide_pkg_url: "https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/30/a8/7a/1c/24/19/42/c0/stm32cubeide-lnx/files/st-stm32cubeide_1.12.1_16088_20230420_1057_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.12.1_16088_20230420_1057_amd64.sh.zip"
             apt_pkg_deps: "unzip wget cmake ninja-build python3 python3-pip python3-virtualenv rsync"
+            user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
     env:
       IDE_PKG_NAME: ${{ matrix.ide_pkg_name }}
       PROJECT_PATH: ${{ github.workspace }}/Projects/${{ matrix.project }}
@@ -55,7 +56,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/cache
-          wget --no-verbose ${{ matrix.ide_pkg_url }}
+          wget "${{ matrix.ide_pkg_url }}" -U "${{ matrix.user_agent }}"
           unzip en.${IDE_PKG_NAME}.sh.zip
           chmod +x ${IDE_PKG_NAME}.sh
           ./${IDE_PKG_NAME}.sh --tar -xf ./${IDE_PKG_NAME}.tar.gz
@@ -96,10 +97,11 @@ jobs:
         project: [b_u585i_iot02a_ntz, b_u585i_iot02a_tfm]
         include:
           - os: windows-latest
-            ide_pkg_name: "st-stm32cubeide_1.10.1_12716_20220707_0928_x86_64"
-            ide_pkg_url: "https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/f6/49/9f/f9/96/8a/47/84/stm32cubeide_win/files/st-stm32cubeide_1.10.1_12716_20220707_0928_x86_64.exe.zip/jcr:content/translations/en.st-stm32cubeide_1.10.1_12716_20220707_0928_x86_64.exe.zip"
+            ide_pkg_name: "st-stm32cubeide_1.12.1_16088_20230420_1057_x86_64"
+            ide_pkg_url: "https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/e8/14/a7/4e/fe/8a/4e/a0/stm32cubeide-win/files/st-stm32cubeide_1.12.1_16088_20230420_1057_x86_64.exe.zip/jcr:content/translations/en.st-stm32cubeide_1.12.1_16088_20230420_1057_x86_64.exe.zip"
             scoop_pkg_deps: "cmake wget git python 7zip ninja"
             pip_pkg_deps: "virtualenv"
+            user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
     env:
       IDE_PKG_NAME: ${{ matrix.ide_pkg_name }}
     steps:
@@ -145,8 +147,9 @@ jobs:
         shell: bash
         if: ${{ steps.cache-ide.outputs.cache-hit != 'true' }}
         run: |
+          export PATH="$(realpath ~/scoop)/shims:${PATH}"
           mkdir -p ~/cache
-          curl -O ${{ matrix.ide_pkg_url }}
+          wget "${{ matrix.ide_pkg_url }}" -U "${{ matrix.user_agent }}"
           7z x en.${{ matrix.ide_pkg_name }}.exe.zip
           mv ${{ matrix.ide_pkg_name }}.exe ~/cache/${{ matrix.ide_pkg_name }}.exe
       - name: Extract IDE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 38b88246ccc552bffaaf54259d064beeee434539 # v4.0.1
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # v4.4.0
     hooks:
     -   id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -32,31 +32,30 @@ repos:
         args : [--fix=lf]
 
 -   repo: https://github.com/ambv/black
-    rev: ae2c0758c9e61a385df9700dc9c231bf54887041 # 22.3.0
+    rev: bf7a16254ec96b084a6caf3d435ec18f0f245cc7 # 23.3.0
     hooks:
     - id: black
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: c6e0d27593a45342ffa96a18bba708a5aab32fdf # 3.9.2
+    rev: b9a7794c4f425ef8419081e6993f99419cc667ea # 6.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear]
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: a6222a8a125ec719724e628a5d3d0d5c60923281 # 5.8.0
+    rev: e44834b7b294701f596c9118d6c370f86671a50d # 5.12.0
     hooks:
     -   id: isort
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: b84ce099a2fd3c5216b6ccf3fd176c3828b075fb # v0.812
+    rev: 6e63c9e9c65e1df04465cdcda0f2490e89291f58 # v1.4.1
     hooks:
     -   id: mypy
+        additional_dependencies: [types-requests]
+        args: [--ignore-missing-imports]
 
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 7cc5848088fd8412905ab79feea6c8edc3ac76c6 # 2.1.5
+    rev: 38980559e3a605691d6579f96222c30778e5a69e # 3.0.0
     hooks:
     -   id: forbid-binary
-    # -   id: git-dirty
-    # -   id: markdownlint
-    # -   id: protect-first-parent
     -   id: shellcheck

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -334,7 +334,6 @@ class AwsHelper:
     arn = None
 
     def __init__(self, args):
-
         # Convert Namespace to dict
         args = vars(args)
 


### PR DESCRIPTION
CI: Update to STM32CubeIDE 1.12.1

Description
-----------
Update to STM32CubeIDE version 1.12.1
Add user-agent when downloading IDE package.
Add scheduled build twice a week to keep the github actions cache updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
