### PR TITLE
Fix RNG interrupt priority

### DIFF
--- a/Common/config/FreeRTOSConfig.h
+++ b/Common/config/FreeRTOSConfig.h
@@ -54,7 +54,7 @@ extern uint32_t SystemCoreClock;
 
 #include CMSIS_device_header
 
-/*-------------------- STM32L5 specific defines -------------------*/
+/*-------------------- STM32U5 specific defines -------------------*/
 #define configENABLE_TRUSTZONE                     0
 #define configRUN_FREERTOS_SECURE_ONLY             0
 #define configENABLE_FPU                           1
@@ -140,16 +140,16 @@ extern uint32_t SystemCoreClock;
 #define USE_FreeRTOS_HEAP_4
 
 /* Cortex-M specific definitions. */
-/* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
+/* __NVIC_PRIO_BITS will be specified when CMSIS is being used. */
 #ifdef __NVIC_PRIO_BITS
 #define configPRIO_BITS    __NVIC_PRIO_BITS
 #else
-#define configPRIO_BITS    3
+#define configPRIO_BITS    4
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
  * function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         7
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         ( ( 1UL << configPRIO_BITS ) - 1 )
 
 /* The highest interrupt priority that can be used by any interrupt service
  * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
@@ -193,7 +193,5 @@ extern uint32_t SystemCoreClock;
 #include "hw_defs.h"
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
 #define portGET_RUN_TIME_COUNTER_VALUE()    ( timer_get_count( pxHndlTim5 ) )
-
-
 
 #endif /* FREERTOS_CONFIG_H */

--- a/Projects/b_u585i_iot02a_ntz/Src/crypto/rng_alt_stm32u5.c
+++ b/Projects/b_u585i_iot02a_ntz/Src/crypto/rng_alt_stm32u5.c
@@ -58,7 +58,7 @@ static void vRngInit( void )
     {
         xRngMutex = xSemaphoreCreateMutex();
         NVIC_SetVector( RNG_IRQn, ( uint32_t ) &vRngIrqHandler );
-        NVIC_SetPriority( RNG_IRQn, 1 );
+        NVIC_SetPriority( RNG_IRQn, configLIBRARY_LOWEST_INTERRUPT_PRIORITY );
         NVIC_EnableIRQ( RNG_IRQn );
     }
 


### PR DESCRIPTION
Fix RNG interrupt priority

Description
-----------
Prior to this PR, the RNG module's interrupt priority was 1, which is a higher priority than configMAX_SYSCALL_INTERRUPT_PRIORITY.  After this PR, the RNG module's interrupt priority is 15, which is the lowest priority.
Since the RNG interrupt handler makes FreeRTOS API calls, it must use a priority lower than configMAX_SYSCALL_INTERRUPT_PRIORITY.

Found this issue while using the latest CM33 port code (10.6.0) with this project.  The latest port code includes validation of interrupt priorities.

Also:
- Updated FreeRTOSConfig.h to reflect that there are 4 priority bits implemented for interrupt priority.  
- Changed the definition of configLIBRARY_LOWEST_INTERRUPT_PRIORITY from 7 to 15 (Note that configLIBRARY_LOWEST_INTERRUPT_PRIORITY is not actually used in this repo, so no impact from this change.)

Test Steps
-----------
Adopt kernel 10.6.0 into this repo.  Prior to this PR, the application asserts due to the interrupt priority.  After this PR, no assertion.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
[X] I have tested my changes. No regression in existing tests.
~[X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~ N/A

Related Issue
-----------
<!-- If any, please provide issue ID. -->
(none)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
