### PR TITLE
Add Memory Usage in README

### DIFF
--- a/Projects/b_u585i_iot02a_ntz/README.md
+++ b/Projects/b_u585i_iot02a_ntz/README.md
@@ -48,10 +48,10 @@ To write the newly built image to flash, select the Run As button, then select t
 
 ### 3.1 Memory Usage
 
-| Memory Usage  | Used          |
-| ------------- | ------------- |
-| RAM           | 519.71 KB     |
-| Flash         | 565.89 KB     |
+| Memory Usage  | Size          | Free          | Used          | Usage         |
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| RAM           | 519.71 KB     | 248.29 KB     | 519.71 KB     | 67.67 %       |
+| Flash         | 2 MB          | 1.45 MB       | 565.89 KB     | 27.63 %       |
 
 ## 4 Flashing the Image from the commandline
 

--- a/Projects/b_u585i_iot02a_ntz/README.md
+++ b/Projects/b_u585i_iot02a_ntz/README.md
@@ -7,6 +7,7 @@ The following Readme.md contains instructions on getting the non-trustzone (b_u5
 &nbsp;&nbsp;&nbsp;&nbsp;[1.3 FreeRTOS OTA Platform Abstraction Layer implementation](#13-freertos-ota-platform-abstraction-layer-implementation)<br>
 [2 Importing the projects into STM32CubeIDE](#2-importing-the-projects-into-stm32cubeide)<br>
 [3 Building and Flashing the Firmware Image](#3-building-and-flashing-the-firmware-image)<br>
+&nbsp;&nbsp;&nbsp;&nbsp;[3.1 Memory Usage](#31-memory-usage)<br>
 [4 Flashing the Image from the commandline](#4-flashing-the-image-from-the-commandline)<br>
 [5 Performing Over-the-air (OTA) Firmware Update](#5-performing-over-the-air-ota-firmware-update)<br>
 [6 Performing Integration Test](#6-performing-integration-test)<br>
@@ -44,6 +45,13 @@ Follow the instructions in the repository [README.md](../../README.md) to import
 After importing the b_u585i_iot02a_ntz project into STM32CubeIDE, Build the project by highlighting it in the *Project Exporer* pane and then clicking **Project -> Build Project** from the menu at the top of STM32CubeIDE.
 
 To write the newly built image to flash, select the Run As button, then select the `Flash_ntz` target.
+
+### 3.1 Memory Usage
+
+| Memory Usage  | Used          |
+| ------------- | ------------- |
+| RAM           | 519.71 KB     |
+| Flash         | 565.89 KB     |
 
 ## 4 Flashing the Image from the commandline
 

--- a/Projects/b_u585i_iot02a_tfm/README.md
+++ b/Projects/b_u585i_iot02a_tfm/README.md
@@ -151,11 +151,11 @@ After importing the b_u585i_iot02a_tfm project into STM32CubeIDE, Build the proj
 
 ### 4.1 Non-Secure Image Memory Usage
 
-| Memory Usage  | Used          |
-| ------------- | ------------- |
-| Flash         | 611.44 KB     |
-| RAM           | 2 KB          |
-| RAM2          | 513.09 KB     |
+| Memory Usage  | Size          | Free          | Used          | Usage         |
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| Flash         | 631 KB        | 19.56 KB      | 611.44 KB     | 96.90 %       |
+| RAM           | 128 KB        | 126 KB        | 2 KB          | 1.57 %        |
+| RAM2          | 528 KB        | 14.91 KB      | 513.09 KB     | 97.18 %       |
 
 ## 5 Customizing the Firmware Metadata for mcuboot
 ### 5.1 Using custom firmware region Signing Keys

--- a/Projects/b_u585i_iot02a_tfm/README.md
+++ b/Projects/b_u585i_iot02a_tfm/README.md
@@ -16,6 +16,7 @@ In addition, the secure region MPU is used to provide isolation between differen
 &nbsp;&nbsp;&nbsp;&nbsp;[3.2 Flash Memory Layout](#32-flash-memory-layout)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;[3.3 Flash Option Byte Configuration](#33-flash-option-byte-configuration)<br>
 [4 Building the Firmware Images](#4-building-the-firmware-images)<br>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.1 Non-Secure Image Memory Usage](#41-non-secure-image-memory-usage)<br>
 [5 Customizing the Firmware Metadata for mcuboot](#5-customizing-the-firmware-metadata-for-mcuboot)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;[5.1 Using custom firmware region Signing Keys](#51-using-custom-firmware-region-signing-keys)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;[5.2 Setting the version number and Anti-Rollback counter for each image](#52-setting-the-version-number-and-anti-rollback-counter-for-each-image)<br>
@@ -147,6 +148,14 @@ Refer to the ST RM0456 document for a more exhaustive description of each option
 
 ## 4 Building the Firmware Images
 After importing the b_u585i_iot02a_tfm project into STM32CubeIDE, Build the project by highlighting it in the *Project Explorer* pane and then clicking **Project -> Build Project** from the menu at the top of STM32CubeIDE.
+
+### 4.1 Non-Secure Image Memory Usage
+
+| Memory Usage  | Used          |
+| ------------- | ------------- |
+| Flash         | 611.44 KB     |
+| RAM           | 2 KB          |
+| RAM2          | 513.09 KB     |
 
 ## 5 Customizing the Firmware Metadata for mcuboot
 ### 5.1 Using custom firmware region Signing Keys


### PR DESCRIPTION
<!--- Title -->
Add Memory Usage in README

Description
-----------
<!--- Describe your changes in detail. -->
Add memory usage info into readme file of NTZ/TFM projects.
Info get from STM32CubeIDE -- Build Analyzer:
- NTZ project
![image](https://github.com/FreeRTOS/iot-reference-stm32u5/assets/13195926/20ecdd58-42b8-4945-904f-4db85069309d)

- TFM project
![image](https://github.com/FreeRTOS/iot-reference-stm32u5/assets/13195926/4f6513e3-c776-4800-9f93-3da1225e6612)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [NA] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
