### PR TITLE
Fix internal NOR littlefs unlock callback

### DIFF
--- a/Projects/b_u585i_iot02a_ntz/Src/fs/lfs_port_internal_nor.c
+++ b/Projects/b_u585i_iot02a_ntz/Src/fs/lfs_port_internal_nor.c
@@ -154,7 +154,7 @@ static void vPopulateConfig( struct lfs_config * pxCfg,
 
     #ifdef LFS_THREADSAFE
         pxCfg->lock = &lfs_port_lock;
-        pxCfg->lock = &lfs_port_unlock;
+        pxCfg->unlock = &lfs_port_unlock;
     #endif
 
     pxCfg->read_size = 1;


### PR DESCRIPTION
Closes #98.

## Summary
- Fix the internal NOR littlefs port so the LFS_THREADSAFE unlock callback is assigned to `pxCfg->unlock`.
- The previous assignment wrote `lfs_port_unlock` into `pxCfg->lock`, overwriting the lock callback.
- This matches the existing OSPI littlefs port configuration.

## Testing
- `git diff --check upstream/main...HEAD`
- Confirmed the diff is limited to the intended one-line callback field change.
- Confirmed `lfs_port_internal_nor.c` remains UTF-8 without BOM and CRLF-only.
- Compared the internal NOR and OSPI littlefs port lock/unlock assignments.

Hardware validation was not run locally because this environment does not have the STM32U5 board/toolchain setup. The change is limited to correcting the callback field assignment.